### PR TITLE
feat(logbook): :sparkles: add transaction logbook for user actions

### DIFF
--- a/SACIT/SACIT/src/main/java/mx/edu/utez/SACIT/repository/TransactionLogRepository.java
+++ b/SACIT/SACIT/src/main/java/mx/edu/utez/SACIT/repository/TransactionLogRepository.java
@@ -1,0 +1,7 @@
+package mx.edu.utez.SACIT.repository;
+
+import mx.edu.utez.SACIT.model.TransactionLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TransactionLogRepository extends JpaRepository<TransactionLog, Long> {
+}

--- a/SACIT/SACIT/src/main/java/mx/edu/utez/SACIT/service/TransactionLogService.java
+++ b/SACIT/SACIT/src/main/java/mx/edu/utez/SACIT/service/TransactionLogService.java
@@ -1,0 +1,32 @@
+package mx.edu.utez.SACIT.service;
+
+import mx.edu.utez.SACIT.model.TransactionLog;
+import mx.edu.utez.SACIT.repository.TransactionLogRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+public class TransactionLogService {
+
+    private final TransactionLogRepository repository;
+
+    public TransactionLogService(TransactionLogRepository repository) {
+        this.repository = repository;
+    }
+
+    public void logTransaction(String transactionType, String tableName, Integer relatedUserId, String details) {
+        // Crea una nueva instancia de TransactionLog
+        TransactionLog log = new TransactionLog();
+        log.setUuid(UUID.randomUUID().toString());  // Cambio aquí, de UUID a String
+        log.setTransactionType(transactionType);
+        log.setTableName(tableName);
+        log.setRelatedUserId(relatedUserId);
+        log.setDetails(details);
+        log.setTransactionDate(LocalDateTime.now());
+
+        // Guarda el log en la base de datos
+        repository.save(log);
+    }
+}


### PR DESCRIPTION
Created a new entity `TransactionLog` to store user-related transaction logs, including fields for UUID, transaction type, table name, user ID, and timestamp.   Also implemented `TransactionLogRepository` and `TransactionLogService` to enable saving logs to the database.

No breaking changes.