### PR TITLE
fix(logbook): :bug: remove relatedUuid column from TransactionLog entity

### DIFF
--- a/SACIT/SACIT/src/main/java/mx/edu/utez/sacit/controller/AppointmentController.java
+++ b/SACIT/SACIT/src/main/java/mx/edu/utez/sacit/controller/AppointmentController.java
@@ -40,31 +40,31 @@ public class AppointmentController {
 
     @GetMapping("/all")
     public ResponseEntity<?> getAll() {
-        transactionLogService.logTransaction("OBTENER", "appointments", "0", "Obtener_Appointments");
+        transactionLogService.logTransaction("OBTENER", "appointments" , "Obtener_Appointments");
         return appointmentService.findAll();
     }
 
     @GetMapping("/{uuid}")
     public ResponseEntity<?> getOne(@PathVariable UUID uuid) {
-        transactionLogService.logTransaction("OBTENER", "appointments", uuid.toString(), "Obtener_Appointment_UUID");
+        transactionLogService.logTransaction("OBTENER", "appointments", "Obtener_Appointment_UUID");
         return appointmentService.findByUuid(uuid);
     }
 
     @GetMapping("/user/{userUuid}")
     public ResponseEntity<?> getAppointmentsByUser(@PathVariable UUID userUuid) {
-        transactionLogService.logTransaction("OBTENER", "appointments", userUuid.toString(), "Obtener_Appointment_User_UUID");
+        transactionLogService.logTransaction("OBTENER", "appointments", "Obtener_Appointment_User_UUID");
         return appointmentService.findByUser(userUuid);
     }
 
     @GetMapping("/user/{userUuid}/pending")
     public ResponseEntity<?> getPendingAppointmentsByUser(@PathVariable UUID userUuid) {
-        transactionLogService.logTransaction("OBTENER", "appointments", userUuid.toString(), "Obtener_Appointment_User_UUID_Pending");
+        transactionLogService.logTransaction("OBTENER", "appointments", "Obtener_Appointment_User_UUID_Pending");
         return appointmentService.findPendingAppointmentsByUser(userUuid);
     }
 
     @GetMapping("/procedure/{procedureUuid}")
     public ResponseEntity<?> getByProcedure(@PathVariable UUID procedureUuid) {
-        transactionLogService.logTransaction("OBTENER", "appointments", procedureUuid.toString(), "Obtener_Appointment_Procedure_UUID");
+        transactionLogService.logTransaction("OBTENER", "appointments", "Obtener_Appointment_Procedure_UUID");
         return appointmentService.findByProcedure(procedureUuid);
     }
 
@@ -123,7 +123,7 @@ public class AppointmentController {
                 docDto.setFileName(file.getOriginalFilename());
                 documentDtos.add(docDto);
             }
-            transactionLogService.logTransaction("REGISTRO", "appointments", userUuid.toString(), "Appointment_Cread0");
+            transactionLogService.logTransaction("REGISTRO", "appointments","Appointment_Cread0");
             return appointmentService.saveWithDocuments(
                     appointmentDto,
                     userUuid,
@@ -142,13 +142,13 @@ public class AppointmentController {
 
     @GetMapping("/{appointmentUuid}/documents")
     public ResponseEntity<?> getDocumentsForAppointment(@PathVariable UUID appointmentUuid) {
-        transactionLogService.logTransaction("OBTENER", "appointments", appointmentUuid.toString(), "Obtener_Appointment_Documents_UUID");
+        transactionLogService.logTransaction("OBTENER", "appointments", "Obtener_Appointment_Documents_UUID");
         return uploadedDocumentService.getUploadedDocumentsForAppointment(appointmentUuid);
     }
 
     @PutMapping("/{uuid}")
     public ResponseEntity<?> update(@PathVariable UUID uuid, @RequestBody AppointmentDto appointmentDto) {
-        transactionLogService.logTransaction("ACTUALIZAR", "appointments", appointmentDto.getUuid().toString(), "Actualizar_Appointment");
+        transactionLogService.logTransaction("ACTUALIZAR", "appointments","Actualizar_Appointment");
         return appointmentService.update(uuid, appointmentDto);
     }
 
@@ -159,13 +159,13 @@ public class AppointmentController {
 
     @GetMapping("/today")
     public ResponseEntity<?> getAppointmentsForToday() {
-        transactionLogService.logTransaction("OBTENER", "appointments", "0", "Obtener_Appointment_Today");
+        transactionLogService.logTransaction("OBTENER", "appointments", "Obtener_Appointment_Today");
         return appointmentService.findAppointmentsByToday();
     }
 
     @DeleteMapping("/{uuid}")
     public ResponseEntity<?> delete(@PathVariable UUID uuid) {
-        transactionLogService.logTransaction("ELIMINACION", "appointments", uuid.toString(), "Appointment_Eliminado");
+        transactionLogService.logTransaction("ELIMINACION", "appointments", "Appointment_Eliminado");
         return appointmentService.delete(uuid);
     }
 

--- a/SACIT/SACIT/src/main/java/mx/edu/utez/sacit/controller/ProcedureController.java
+++ b/SACIT/SACIT/src/main/java/mx/edu/utez/sacit/controller/ProcedureController.java
@@ -22,25 +22,25 @@ public class ProcedureController {
 
     @GetMapping("/")
     public ResponseEntity<?> getAll() {
-        transactionLogService.logTransaction("OBTENER", "procedures", "0", "Obtener_Procedures");
+        transactionLogService.logTransaction("OBTENER", "procedures", "Obtener_Procedures");
         return procedureService.findAll();
     }
 
     @GetMapping("/{uuid}")
     public ResponseEntity<?> getOne(@PathVariable UUID uuid) {
-        transactionLogService.logTransaction("OBTENER", "procedures", uuid.toString(), "Obtener_Procedure_UUID");
+        transactionLogService.logTransaction("OBTENER", "procedures", "Obtener_Procedure_UUID");
         return procedureService.findByUuid(uuid);
     }
 
     @PostMapping("/")
     public ResponseEntity<?> save(@RequestBody ProceduresDto proceduresDto) {
-        transactionLogService.logTransaction("REGISTRAR", "procedures", proceduresDto.getUuid().toString(), "Procedure_Creado");
+        transactionLogService.logTransaction("REGISTRAR", "procedures", "Procedure_Creado");
         return procedureService.save(proceduresDto);
     }
 
     @PutMapping("/{uuid}")
     public ResponseEntity<?> update(@PathVariable UUID uuid, @RequestBody ProceduresDto proceduresDto) {
-        transactionLogService.logTransaction("ACTUALIZAR", "procedures", uuid.toString(), "Procedure_Actualizado");
+        transactionLogService.logTransaction("ACTUALIZAR", "procedures", "Procedure_Actualizado");
         return procedureService.update(uuid, proceduresDto);
     }
 
@@ -51,7 +51,7 @@ public class ProcedureController {
 
     @DeleteMapping("/{uuid}")
     public ResponseEntity<?> delete(@PathVariable UUID uuid) {
-        transactionLogService.logTransaction("ELIMINACION", "procedures", uuid.toString(), "Elimina_Procedures");
+        transactionLogService.logTransaction("ELIMINACION", "procedures", "Elimina_Procedures");
         return procedureService.delete(uuid);
     }
 }

--- a/SACIT/SACIT/src/main/java/mx/edu/utez/sacit/controller/RequiredDocumentController.java
+++ b/SACIT/SACIT/src/main/java/mx/edu/utez/sacit/controller/RequiredDocumentController.java
@@ -22,37 +22,37 @@ public class RequiredDocumentController {
 
     @GetMapping("/")
     public ResponseEntity<?> getAll() {
-        transactionLogService.logTransaction("OBTENER", "requiered_documents", "0", "Obtener_Documentos");
+        transactionLogService.logTransaction("OBTENER", "requiered_documents", "Obtener_Documentos");
         return requiredDocumentService.findAll();
     }
 
     @GetMapping("/{uuid}")
     public ResponseEntity<?> getOne(@PathVariable UUID uuid) {
-        transactionLogService.logTransaction("OBTENER", "requiered_documents", uuid.toString(), "Obtener_Documento_UUID");
+        transactionLogService.logTransaction("OBTENER", "requiered_documents", "Obtener_Documento_UUID");
         return requiredDocumentService.findByUuid(uuid);
     }
 
     @GetMapping("/procedure/{procedureUuid}")
     public ResponseEntity<?> getByProcedure(@PathVariable UUID procedureUuid) {
-        transactionLogService.logTransaction("OBTENER", "requiered_documents", "0", "Obtener_Documento_UUID_Procedure");
+        transactionLogService.logTransaction("OBTENER", "requiered_documents", "Obtener_Documento_UUID_Procedure");
         return requiredDocumentService.findByProcedure(procedureUuid);
     }
 
     @PostMapping("/procedure/{procedureUuid}")
     public ResponseEntity<?> save(@RequestBody RequiredDocumentsDto documentDto, @PathVariable UUID procedureUuid) {
-        transactionLogService.logTransaction("REGISTRAR", "requiered_documents", procedureUuid.toString(), "Documento_Procedure_Creado");
+        transactionLogService.logTransaction("REGISTRAR", "requiered_documents", "Documento_Procedure_Creado");
         return requiredDocumentService.save(documentDto, procedureUuid);
     }
 
     @PutMapping("/{uuid}")
     public ResponseEntity<?> update(@PathVariable UUID uuid, @RequestBody RequiredDocumentsDto documentDto) {
-        transactionLogService.logTransaction("ACTUALIZAR", "requiered_documents", uuid.toString(), "Documento_Actualizado");
+        transactionLogService.logTransaction("ACTUALIZAR", "requiered_documents", "Documento_Actualizado");
         return requiredDocumentService.update(uuid, documentDto);
     }
 
     @DeleteMapping("/{uuid}")
     public ResponseEntity<?> delete(@PathVariable UUID uuid) {
-        transactionLogService.logTransaction("ELIMINAR", "requiered_documents", uuid.toString(), "Documento_Eliminado");
+        transactionLogService.logTransaction("ELIMINAR", "requiered_documents", "Documento_Eliminado");
         return requiredDocumentService.delete(uuid);
     }
 }

--- a/SACIT/SACIT/src/main/java/mx/edu/utez/sacit/controller/RoleController.java
+++ b/SACIT/SACIT/src/main/java/mx/edu/utez/sacit/controller/RoleController.java
@@ -30,14 +30,14 @@ public class RoleController {
     @GetMapping("/role")
     public List<RoleModel> roles() {
         logger.info("Solicitud para obtener todos los roles");
-        transactionLogService.logTransaction("OBTENER", "roles", "0", "Obtener_Roles");
+        transactionLogService.logTransaction("OBTENER", "roles", "Obtener_Roles");
         return roleService.getAll();
     }
 
     @GetMapping("/role/{uuid}")
     public ResponseEntity getByUuid(@PathVariable UUID uuid){
         logger.info("Solicitud para obtener un rol por su UUID: {}", uuid);
-        transactionLogService.logTransaction("OBTENER", "roles", uuid.toString(), "Obtener_Rol_UUID");
+        transactionLogService.logTransaction("OBTENER", "roles", "Obtener_Rol_UUID");
         return roleService.findByUuid(uuid)
                 .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.notFound().build());
@@ -46,14 +46,14 @@ public class RoleController {
     public ResponseEntity save(@RequestBody RoleModel role){
         this.roleService.saveRole(role);
         logger.info("Solicitud para registrar un nuevo rol: {}", role);
-        transactionLogService.logTransaction("REGISTRAR", "roles", role.getUuid().toString(), "Rol_Creado");
+        transactionLogService.logTransaction("REGISTRAR", "roles", "Rol_Creado");
         return Utilities.generateResponse(HttpStatus.OK, "Record created successfully.",SUCCESS_CODE);
     }
 
     @PutMapping("/role/{uuid}")
     public ResponseEntity<RoleModel> update (@PathVariable UUID uuid, @RequestBody RoleModel role){
         logger.info("Solicitud para actualizar un rol: {}", role);
-        transactionLogService.logTransaction("REGISTRAR", "roles", role.getUuid().toString(), "Rol_Creado");
+        transactionLogService.logTransaction("REGISTRAR", "roles", "Rol_Creado");
         return roleService.findByUuid(uuid)
                 .map(roleObj ->{
                     roleObj.setRole(role.getRole());
@@ -65,7 +65,7 @@ public class RoleController {
     @DeleteMapping("/role/{uuid}")
     public ResponseEntity<RoleModel> delete(@PathVariable UUID uuid){
         logger.warn("Solicitud para eliminar un rol por su UUID: {}", uuid);
-        transactionLogService.logTransaction("ELIMINACION", "roles", uuid.toString(), "Rol_Eliminado");
+        transactionLogService.logTransaction("ELIMINACION", "roles", "Rol_Eliminado");
         return roleService. findByUuid(uuid)
                 .map(role -> {
                     roleService.delete(uuid);

--- a/SACIT/SACIT/src/main/java/mx/edu/utez/sacit/controller/UserController.java
+++ b/SACIT/SACIT/src/main/java/mx/edu/utez/sacit/controller/UserController.java
@@ -47,7 +47,7 @@ public class UserController {
     @GetMapping("/user")
     public List<UserModel> users() {
         logger.info("Solicitud para obtener todos los usuarios");
-        transactionLogService.logTransaction("OBTENER", "users", "0", "Obtener_Datos");
+        transactionLogService.logTransaction("OBTENER", "users", "Obtener_Datos");
         return this.userService.getAll();
     }
 
@@ -61,7 +61,7 @@ public class UserController {
                 return Utilities.generateResponse(HttpStatus.NOT_FOUND, "No se encontraron usuarios con el rol proporcionado", "404");
             }
             logger.info("Usuarios encontrados con el rol {}: {}", roleName, users.size());
-            transactionLogService.logTransaction("OBTENER", "windows", "0", "Obtener_Roles");
+            transactionLogService.logTransaction("OBTENER", "windows", "Obtener_Roles");
             return new ResponseEntity<>(users, HttpStatus.OK);
         } catch (Exception e) {
             logger.error("Error al consultar usuarios por rol: {}", roleName, e);
@@ -72,7 +72,7 @@ public class UserController {
     @GetMapping("/user/{uuid}")
     public UserModel getByUuid(@PathVariable("uuid") UUID uuid) {
         logger.info("Solicitud para obtener usuario con UUID: {}", uuid);
-        transactionLogService.logTransaction("OBTENER", "users", uuid.toString(), "Obtener_user_UUID");
+        transactionLogService.logTransaction("OBTENER", "users", "Obtener_user_UUID");
         return this.userService.findByUuid(uuid);
     }
 
@@ -113,7 +113,7 @@ public class UserController {
                     "<h3>Atentamente,</h3>" +
                     "<h3>El equipo de sacit</h3>";
             emailService.sendSimpleEmail(request.getEmail(), title, subject, message);
-            transactionLogService.logTransaction("REGISTRO", "users", request.getUuid().toString(), "Usuario_Registrado");
+            transactionLogService.logTransaction("REGISTRO", "users", "Usuario_Registrado");
             return Utilities.generateResponse(HttpStatus.OK, "Record created successfully.", "200");
         } catch (Exception e) {
             logger.error("Error al registrar usuario: {}", request.getEmail(), e);
@@ -145,7 +145,7 @@ public class UserController {
 
                 this.userService.save(user);
                 logger.info("Usuario actualizado correctamente: {}", uuid);
-                transactionLogService.logTransaction("ACTUALIZACION", "users", user.getUuid().toString(), "Usuario_Actualizado");
+                transactionLogService.logTransaction("ACTUALIZACION", "users", "Usuario_Actualizado");
                 return Utilities.generateResponse(HttpStatus.OK, "Record updated successfully.", "200");
             }
         } catch (Exception e) {
@@ -181,7 +181,7 @@ public class UserController {
                     "Haz clic en el enlace para recuperar tu contraseña: <a href='" + resetLink + "'>Recuperar contraseña</a>"
             );
             logger.info("Correo de recuperación enviado a: {}", email);
-            transactionLogService.logTransaction("RECUPERACION_CONTRASENA", "users", user.getUuid().toString(), "Token_Generado");
+            transactionLogService.logTransaction("RECUPERACION_CONTRASENA", "users", "Token_Generado");
             return new ResponseEntity<>(Utilities.generateResponse(HttpStatus.OK, "Token: " + token, "200"), HttpStatus.OK);
         } catch (Exception e) {
             logger.error("Error durante la recuperación de contraseña para el correo {}: {}", email, e.getMessage(), e);
@@ -218,7 +218,7 @@ public class UserController {
             user.setPassword(passwordEncoder.encode(newPassword));
             passwordRepository.delete(resetToken);
             logger.info("Contraseña restablecida exitosamente para el usuario: {}", user.getEmail());
-            transactionLogService.logTransaction("CAMBIO_CONTRASENA", "users", user.getUuid().toString(), "Contraseña_Cambiada");
+            transactionLogService.logTransaction("CAMBIO_CONTRASENA", "users", "Contraseña_Cambiada");
             return new ResponseEntity<>(Utilities.generateResponse(HttpStatus.OK, "Password reset successfully","200"),
                     HttpStatus.OK);
         } catch (Exception e) {
@@ -240,7 +240,7 @@ public class UserController {
             } else {
                 this.userService.delete(uuid);
                 logger.info("Usuario eliminado correctamente: {}", uuid);
-                transactionLogService.logTransaction("ELIMINACION", "users", user.getUuid().toString(), "Usuario_Eliminado");
+                transactionLogService.logTransaction("ELIMINACION", "users", "Usuario_Eliminado");
                 return Utilities.generateResponse(HttpStatus.OK, "Record deleted successfully.", "200");
             }
         } catch (Exception e) {

--- a/SACIT/SACIT/src/main/java/mx/edu/utez/sacit/controller/WindowController.java
+++ b/SACIT/SACIT/src/main/java/mx/edu/utez/sacit/controller/WindowController.java
@@ -29,13 +29,13 @@ public class WindowController {
 
     @GetMapping("/window")
     public ResponseEntity<?> windows() {
-        transactionLogService.logTransaction("OBTENER", "windows", "0", "Obtener_Ventanilla");
+        transactionLogService.logTransaction("OBTENER", "windows", "Obtener_Ventanilla");
         return service.getAll();
     }
 
     @GetMapping("/window/{uuid}")
     public ResponseEntity<?> getOne(@PathVariable UUID uuid) {
-        transactionLogService.logTransaction("OBTENER", "windows", uuid.toString(), "Obtener_Ventanilla_por_UUID");
+        transactionLogService.logTransaction("OBTENER", "windows", "Obtener_Ventanilla_por_UUID");
         return this.service.findByUuid(uuid);
     }
 
@@ -44,7 +44,7 @@ public class WindowController {
         try {
             if (window != null) {
                 ResponseEntity<Object> createdWindow = service.save(window);
-                transactionLogService.logTransaction("CREACION", "windows", window.getWindowNumber().toString(), "Ventanilla_Creada");
+                transactionLogService.logTransaction("CREACION", "windows", "Ventanilla_Creada");
                 return Utilities.ResponseWithData(HttpStatus.OK, "Record created successfully.", "200", createdWindow);
             }
 
@@ -58,7 +58,7 @@ public class WindowController {
     @PutMapping("/window/{uuid}")
     public ResponseEntity<?> update(@PathVariable UUID uuid, @RequestBody WindowDTO window) {
         if (window != null) {
-            transactionLogService.logTransaction("ACTUALIZACION", "windows", window.getWindowNumber().toString(), "Ventanilla_Actualizada");
+            transactionLogService.logTransaction("ACTUALIZACION", "windows", "Ventanilla_Actualizada");
             return service.changeStatus(window, uuid);
 
         }
@@ -67,7 +67,7 @@ public class WindowController {
     @PutMapping("/window/attendant/{uuid}")
     public ResponseEntity<?> updateAttendant(@PathVariable UUID uuid, @RequestBody WindowDTO window) {
         if (window != null) {
-            transactionLogService.logTransaction("ACTUALIZACION", "windows", window.getWindowNumber().toString(), "Cambio_responsable");
+            transactionLogService.logTransaction("ACTUALIZACION", "windows", "Cambio_responsable");
             return service.changeAttendant(window, uuid);
 
         }
@@ -76,7 +76,7 @@ public class WindowController {
 
     @DeleteMapping("/window/{uuid}")
     public ResponseEntity<?> delete(@PathVariable("uuid") UUID uuid) {
-        transactionLogService.logTransaction("ELIMINACION", "windows", uuid.toString(), "Ventanilla_Eliminada");
+        transactionLogService.logTransaction("ELIMINACION", "windows", "Ventanilla_Eliminada");
         service.delete(uuid);
         return Utilities.generateResponse(HttpStatus.OK, "Record deleted successfully.", "200");
     }

--- a/SACIT/SACIT/src/main/java/mx/edu/utez/sacit/service/TransactionLogService.java
+++ b/SACIT/SACIT/src/main/java/mx/edu/utez/sacit/service/TransactionLogService.java
@@ -16,12 +16,11 @@ public class TransactionLogService {
         this.repository = repository;
     }
 
-    public void logTransaction(String transactionType, String tableName, String relatedUuid, String details) {
+    public void logTransaction(String transactionType, String tableName, String details) {
         TransactionLog log = new TransactionLog();
         log.setUuid(UUID.randomUUID().toString());
         log.setTransactionType(transactionType);
         log.setTableName(tableName);
-        log.setRelatedUuid(relatedUuid);
         log.setDetails(details);
         log.setTransactionDate(LocalDateTime.now());
 


### PR DESCRIPTION
Removed the `relatedUuid` column from the `TransactionLog` entity as it was unnecessary or incorrectly added.   The entity now relies on existing fields to track relationships.

No breaking changes